### PR TITLE
0.1.5 - set_formatter now accepts message as array, converting it to …

### DIFF
--- a/lib/rlogger/default_logger.rb
+++ b/lib/rlogger/default_logger.rb
@@ -92,6 +92,7 @@ module RLogger
 
     def set_formatter
       self.formatter = proc { |severity, datetime, progname, msg|
+        msg = msg.join(", ") if msg.is_a? Enumerable
         config[:formatter].call(severity, datetime, progname, msg.dump)
       }
     end

--- a/rlogger.gemspec
+++ b/rlogger.gemspec
@@ -3,7 +3,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'rlogger'
-  s.version     = '0.1.4'
+  s.version     = '0.1.5'
   s.date        = '2016-12-26'
   s.summary     = "RLogger"
   s.description = "Ruby default logger for EV Ruby Applications"


### PR DESCRIPTION
…string

I chose to fix in rlogger to permit logging backtraces without apps having to explicitly convert it.

As in:
```ruby
@logger.warn(e.backtrace)
```